### PR TITLE
Add a `usesPeriodicBoundaryConditions` method to the Force plugin

### DIFF
--- a/openmmapi/include/ExampleForce.h
+++ b/openmmapi/include/ExampleForce.h
@@ -96,6 +96,14 @@ public:
      * in a bond cannot be changed, nor can new bonds be added.
      */
     void updateParametersInContext(OpenMM::Context& context);
+    /**
+     * Returns true if the force uses periodic boundary conditions and false otherwise. Your force should implement this
+     * method appropriately to ensure that `System.usesPeriodicBoundaryConditions()` works for all systems containing
+     * your force.
+     */
+    bool usesPeriodicBoundaryConditions() const {
+        return false;
+    }
 protected:
     OpenMM::ForceImpl* createImpl() const;
 private:


### PR DESCRIPTION
It's now part of the standard OpenMM API, and I figure the examples ought to demonstrate it.